### PR TITLE
Add fantasy-land 2.1 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "northbrook": "^3.2.1",
     "rollup": "^0.36.3",
     "rollup-plugin-buba": "^1.0.1"
+  },
+  "dependencies": {
+    "fantasy-land": "^2.1.0"
   }
 }

--- a/src/FutureValue.js
+++ b/src/FutureValue.js
@@ -1,4 +1,5 @@
 import * as F from './fn'
+import fl from 'fantasy-land'
 
 // Conceptually, a FutureValue is a value that becomes known
 // at a specific time (the temperature outside next Tuesday at 5pm).
@@ -17,11 +18,7 @@ export class FutureValue {
     return of(x)
   }
 
-  of (x) {
-    return of(x)
-  }
-
-  never () {
+  static never () {
     return never
   }
 
@@ -37,8 +34,8 @@ export class FutureValue {
     return map(f, this)
   }
 
-  ap (fvab) {
-    return lift2(F.apply, fvab, this)
+  ap (f) {
+    return lift2(F.apply, f, this)
   }
 
   chain (f) {
@@ -56,6 +53,40 @@ export class FutureValue {
   write (t, x) {
     setFuture(t, x, this)
     return this
+  }
+
+  // Fantasy-land
+
+  static [fl.of] (a) {
+    return FutureValue.of(a)
+  }
+
+  static [fl.zero] () {
+    return FutureValue.never()
+  }
+
+  [fl.alt] (fv) {
+    return this.or(fv)
+  }
+
+  [fl.concat] (fv) {
+    return this.concat(fv)
+  }
+
+  [fl.map] (f) {
+    return this.map(f)
+  }
+
+  [fl.ap] (f) {
+    return this.ap(f)
+  }
+
+  [fl.chain] (f) {
+    return this.chain(f)
+  }
+
+  [fl.extend] (f) {
+    return this.extend(f)
   }
 }
 
@@ -85,6 +116,10 @@ export const never = new (class Never extends FutureValue {
   }
 
   map (f) {
+    return this
+  }
+
+  ap (f) {
     return this
   }
 

--- a/src/Task.js
+++ b/src/Task.js
@@ -1,6 +1,7 @@
 import { pending, when, FutureValue } from './FutureValue'
 import { killBoth, killWith, neverKill } from './kill'
 import * as F from './fn'
+import fl from 'fantasy-land'
 
 // run :: Task a -> [Kill, FutureValue a]
 // Execute a Task that will produce a result.  Returns a function to
@@ -44,10 +45,6 @@ export class Task {
     return of(x)
   }
 
-  of (x) {
-    return of(x)
-  }
-
   static never () {
     return fromFutureValue(FutureValue.never())
   }
@@ -82,6 +79,40 @@ export class Task {
 
   toString () {
     return `Task { runTask: ${this.runTask}, state: ${this.state} }`
+  }
+
+  // Fantasy-land
+
+  static [fl.of] (a) {
+    return Task.of(a)
+  }
+
+  static [fl.zero] () {
+    return Task.never()
+  }
+
+  [fl.alt] (t2) {
+    return this.or(t2)
+  }
+
+  [fl.concat] (t2) {
+    return this.concat(t2)
+  }
+
+  [fl.map] (tfab) {
+    return this.map(tfab)
+  }
+
+  [fl.ap] (tf) {
+    return this.ap(tf)
+  }
+
+  [fl.chain] (atb) {
+    return this.chain(atb)
+  }
+
+  [fl.extend] (tab) {
+    return this.extend(tab)
   }
 }
 


### PR DESCRIPTION
Add namespaced aliases for fantasy-land 2.1 Semigroup, Alt, Plus, Functor, Apply, Applicative, Chain (and Monad), Extend.